### PR TITLE
Use `quit-window' instead of `kill-buffer-and-window`.

### DIFF
--- a/edit-indirect.el
+++ b/edit-indirect.el
@@ -337,7 +337,8 @@ called with updated positions."
   ;; Kill the overlay reference so that `edit-indirect--abort-on-kill-buffer'
   ;; won't try to call us again.
   (setq edit-indirect--overlay nil)
-  (kill-buffer-and-window))
+  ;; If we created a window, get rid of it.  Kill the buffer we created.
+  (quit-window t))
 
 (defun edit-indirect--abort-on-kill-buffer ()
   "Abort indirect edit.


### PR DESCRIPTION
This should (I think) let previously split frames retain their
splits.
