### PR TITLE
Add before-commit-hook

### DIFF
--- a/edit-indirect.el
+++ b/edit-indirect.el
@@ -63,6 +63,16 @@ Note that the buffer-local value from the parent buffer is used."
   :type 'hook
   :group 'edit-indirect)
 
+(defcustom edit-indirect-before-commit-hook nil
+  "Functions called before the edit-indirect buffer is committed.
+The functions are called with the edit-indirect buffer as the
+current buffer.
+
+Note that the buffer-local value from the edit-indirect buffer is
+used."
+  :type 'hook
+  :group 'edit-indirect)
+
 (defcustom edit-indirect-before-commit-functions nil
   "Functions called before an edit-indirect buffer is committed.
 The functions are called with the parent buffer as the current
@@ -296,6 +306,7 @@ No error is signaled if `inhibit-read-only' or
 
 (defun edit-indirect--commit ()
   "Commit the modifications done in an edit-indirect buffer."
+  (run-hooks 'edit-indirect-before-commit-hook)
   (let ((beg (overlay-start edit-indirect--overlay))
         (end (overlay-end edit-indirect--overlay))
         (buffer (current-buffer))


### PR DESCRIPTION
Provide a hook to be called before committing changes with the
edit-indirect buffer as the current buffer. Will be called before the
edit-indirect-before-commit-functions hook.

This provides the necessary symmetry for doing per-edit custom hooks;
in an edit-indirect-after-create-hook you can add a buffer-local
edit-indirect-before-commit-hook, which will then be called only when
the then-active edit is comitted. You cannot use
edit-indirect-before-commit-functions for that since that hook is
called from the parent buffer (so it will apply to any edit committed
to the parent buffer).