### PR TITLE
Add edit-indirect-save function and keybinding

### DIFF
--- a/edit-indirect.el
+++ b/edit-indirect.el
@@ -161,6 +161,7 @@ In any case, return the edit-indirect buffer."
 
 (defvar edit-indirect-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-x C-s") #'edit-indirect-save)
     (define-key map (kbd "C-c '") #'edit-indirect-commit)
     (define-key map (kbd "C-c C-c") #'edit-indirect-commit)
     (define-key map (kbd "C-c C-k") #'edit-indirect-abort)
@@ -181,6 +182,17 @@ buffer."
   (edit-indirect--barf-if-not-indirect)
   (edit-indirect--commit)
   (edit-indirect--clean-up))
+
+(defun edit-indirect-save ()
+  "Save the modifications done in an edit-indirect buffer.
+That is, replace the original region in the parent buffer with the
+contents of the edit-indirect buffer.
+
+Can be called only when the current buffer is an edit-indirect
+buffer."
+  (interactive)
+  (edit-indirect--barf-if-not-indirect)
+  (edit-indirect--commit))
 
 (defun edit-indirect-abort ()
   "Abort indirect editing in the current buffer and kill the buffer.


### PR DESCRIPTION
Act the same way as `org-edit-src-save` which is also
bound to `C-x C-s`.
When editing an indirect buffer you most likely don't want
to save that buffer to a new file on disk but rather update
the region only.