### PR TITLE
Don't modify buffer if nothing changed

### DIFF
--- a/edit-indirect.el
+++ b/edit-indirect.el
@@ -341,9 +341,11 @@ No error is signaled if `inhibit-read-only' or
            'edit-indirect-before-commit-functions beg-marker end-marker)
           (save-match-data
             (set-match-data (list beg-marker end-marker))
-            (replace-match (with-current-buffer buffer
-                             (buffer-substring-no-properties 1 (1+ (buffer-size))))
-                           t t))
+            (let ((new-data
+                   (with-current-buffer buffer
+                     (buffer-substring-no-properties 1 (1+ (buffer-size))))))
+              (unless (string= new-data (match-string 0))
+                (replace-match new-data t t))))
           (edit-indirect--run-hook-with-positions
            'edit-indirect-after-commit-functions beg-marker (point))
           (set-marker beg-marker nil)


### PR DESCRIPTION
```elisp
(with-temp-buffer
  (insert "foobar")
  (set-buffer-modified-p nil)
  (with-current-buffer (edit-indirect-region (point-min) (point-max))
    (edit-indirect-commit))
  (cl-assert (equal (buffer-string) "foobar"))
  (cl-assert (not (buffer-modified-p))))
;; => error: (cl-assertion-failed ((not (buffer-modified-p)) nil))
```
